### PR TITLE
chore: Automate container image building

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,82 @@
+name: Docker
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+  pull_request:
+    branches:
+      - main
+      - master
+
+env:
+  PLATFORMS: "linux/amd64,linux/arm64"
+
+concurrency:
+  group: ${{ github.ref_name }}-docker
+  cancel-in-progress: true
+
+jobs:
+  build-docker:
+    name: Build Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: --debug
+          driver-opts: network=host
+
+      - name: DockerHub Login
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+        if: github.event_name != 'pull_request'
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        if: github.event_name != 'pull_request'
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            name=${{ github.repository_owner }}/rails-app-operator,enable=${{ github.event_name != 'pull_request' }}
+            name=ghcr.io/${{ github.repository_owner }}/rails-app-operator,enable=${{ github.event_name != 'pull_request' }}
+          tags: |
+            type=edge
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          pull: true
+          push: true
+          platforms: "linux/amd64,linux/arm64"
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          cache-from: type=gha,scope=${{ matrix.os }}
+          cache-to: type=gha,scope=${{ matrix.os }},mode=max
+          target: final


### PR DESCRIPTION
Build for platform `linux/arm64` and `linux/amd64`. 
Add tag base on git tags:

`edge` - any last build
`latest` - last build base on default branch changes `vx.y.z` - build connected to the git tag
`pr-xxx` - build related to PR

Build images in Dockerhub and Github packages.
For DockerHub it requires secrets: DOCKER_USERNAME and DOCKER_PASSWORD

## Tophat

Example of job for my fork push to master branch: https://github.com/miry/rails_app_operator/actions/runs/8868090021/job/24347314572

Example of job for my fork for new tag: https://github.com/miry/rails_app_operator/actions/runs/8868182984/job/24347505933

Results: 
* https://hub.docker.com/r/miry/rails-app-operator/tags
* https://github.com/miry/rails_app_operator/pkgs/container/rails-app-operator
